### PR TITLE
Docs fix for http.Client customization

### DIFF
--- a/content/articles/override-http-client-adapter.md
+++ b/content/articles/override-http-client-adapter.md
@@ -1,6 +1,6 @@
 ---
 title: "Override HTTP Client Adapter"
-date: 2021-12-09T23:10:10-03:00
+date: 2022-04-06T18:38:10-01:00
 ---
 
 An example on how to override and use a more advanced HTTP client.
@@ -9,13 +9,11 @@ Here the `connectionTimeout` is increased, and an HTTP proxy enabled.
 
 ```dart
 mixin HttpProxyAdapter<T extends DataModel<T>> on RemoteAdapter<T> {
-  HttpClient? _httpClient;
-  IOClient? _ioClient;
 
   @override
   http.Client get httpClient {
-    _httpClient ??= HttpClient();
-    _ioClient ??= IOClient(_httpClient);
+    _httpClient = HttpClient();
+    _ioClient = IOClient(_httpClient);
 
     // increasing the timeout
     _httpClient!.connectionTimeout = const Duration(seconds: 5);
@@ -26,14 +24,6 @@ mixin HttpProxyAdapter<T extends DataModel<T>> on RemoteAdapter<T> {
     _httpClient!.findProxy = (uri) => 'PROXY (proxy url)';
 
     return _ioClient!;
-  }
-
-  @override
-  Future<void> dispose() async {
-    _ioClient?.close();
-    _ioClient = null;
-    _httpClient = null;
-    super.dispose();
   }
 }
 ```


### PR DESCRIPTION
Hi Frank! I think I've found an error on the docs so I try to propose a change. In fact, with the latest version of flutter data, it seems that with your previous setup the client get used more than one time (because dispose was never called) causing some trouble to all the callers except the first one.